### PR TITLE
109 user profile test

### DIFF
--- a/backend/templates/search_results.html
+++ b/backend/templates/search_results.html
@@ -99,7 +99,11 @@
         {% for user in users %}
           <div class="user-card">
             <a href="{% url 'user_detail' user.username %}">
-              <img src="{% static 'backend/img/generic_user_image.png' %}" alt="User Image" class="user-card-img" alt="{{ user.username }}" style="cursor: pointer; object-fit: cover" />
+              {% if user.profile.avatar %}
+              <img src="/media/{{ user.profile.avatar }}" alt="User Image" class="user-card-img" style="cursor: pointer; object-fit: cover; border-radius: 50%;" />
+              {% else %}
+              <img src="{% static 'backend/img/generic_user_image.png' %}" alt="User Image" class="user-card-img" style="cursor: pointer; object-fit: cover; border-radius: 50%;" />
+              {% endif %}
               <h5 class="card-title">{{ user.username }}</h5>
             </a>
           </div>

--- a/backend/tests/test_urls.py
+++ b/backend/tests/test_urls.py
@@ -88,6 +88,10 @@ class TestUrls(TestCase):
         url = reverse("interest_list")
         self.assertEqual(resolve(url).func, views.interest_list_handlers.interest_list)
 
+    def test_profile_edit_url_is_resolved(self):
+        url = reverse("profile_edit")
+        self.assertEqual(resolve(url).func, views.profile_handlers.profile_edit)
+
     def test_search_history_url(self):
         view = resolve("/user/search_history/")
         self.assertEqual(view.func, views.base.search_history)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -37,10 +37,13 @@ urlpatterns = [
     ),
     # AJAX
     path(
-        "events/<int:event_id>/add-interest/", views.interest_list_handlers.add_interest
+        "events/<int:event_id>/add-interest/",
+        views.interest_list_handlers.add_interest,
+        name="interest_list_handlers.add_interest",
     ),
     path(
         "events/<int:event_id>/remove-interest/",
         views.interest_list_handlers.remove_interest,
+        name="interest_list_handlers.remove_interest",
     ),
 ]

--- a/backend/views/profile_handlers.py
+++ b/backend/views/profile_handlers.py
@@ -17,7 +17,7 @@ def profile_edit(request):
             user_form.save()
             profile_form.save()
             messages.success(request, "Profile is updated successfully")
-            return redirect(to="profile_edit")
+            return redirect("user_detail", username=request.user.username)
     else:
         user_form = UpdateUserForm(instance=request.user)
         profile_form = UpdateProfileForm(instance=request.user.profile)


### PR DESCRIPTION
Unit tests:
1. user profile & interest list
2. renamed `\tests_views` to `\test_views`

Small fixes on the following requests:
1. After a user changes their profile, maybe redirect to the user home page instead of staying on the editing page.
2. After loading a profile picture, the avatar on the search for user result page is still default, so maybe update on that as well to reflect the change.